### PR TITLE
Restaura Google AdSense e remove links do curso dos menus

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -25,23 +25,7 @@
       href="https://fonts.googleapis.com/css?family=Galdeano"
       rel="stylesheet"
     />
-
-    <script>
-      if (document.location.hostname != 'localhost') {
-        window.addEventListener('DOMContentLoaded', function () {
-          var checkoutButtons = document.querySelectorAll('.js-course-checkout');
-          checkoutButtons.forEach(function (btn) {
-            btn.addEventListener('click', function () {
-              if (typeof gtag === 'function') {
-                gtag('event', 'course_checkout_click', {
-                  event_category: 'Curso Go Iniciantes',
-                  event_label: 'Landing - Botão Inscreva-se',
-                });
-              }
-            });
-          });
-        });
-      }
-    </script>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1641452063803045"
+     crossorigin="anonymous"></script>
 
   </head>

--- a/layouts/partials/sidenavigation.html
+++ b/layouts/partials/sidenavigation.html
@@ -2,16 +2,6 @@
   <nav class="main-nav">
     {{ $currentPage := . }}
     
-    <!-- Curso em destaque -->
-    <div class="nav-course-destaque">
-      <a href="https://buy.stripe.com/00w28rabVdmV5Av2Q62ZO00" target="_blank" rel="noopener" class="nav-course-link js-course-checkout">
-        <span class="nav-course-badge">📣 Curso</span>
-        <span class="nav-course-title">Go para Iniciantes</span>
-        <span class="nav-course-sub">Aulas individuais · 30 dias · R$ 97,00</span>
-        <span class="nav-course-cta">Aulas diárias por WhatsApp + PDF (10 Erros Fatais de quem começa no Go) + análise de partidas + videochamada. De iniciante a 20 kyu. — Inscreva-se</span>
-      </a>
-    </div>
-    
     <!-- Tutorial -->
     <div class="nav-section">
       <h3 class="nav-title">{{ with .Site.Params.main.name }}{{.}}{{ end }}</h3>

--- a/layouts/partials/topnavigation.html
+++ b/layouts/partials/topnavigation.html
@@ -17,11 +17,6 @@
         <button class="mobile-nav-close" aria-label="Fechar menu">×</button>
       </div>
       
-      <!-- Curso em destaque -->
-      <div class="mobile-nav-course-destaque">
-        <a href="/curso-go-iniciantes">📣 Curso Go para Iniciantes — aulas individuais (WhatsApp + PDF + análise + call) →</a>
-      </div>
-      
       <!-- Tutorial -->
       <div class="mobile-nav-section">
         <h3 class="mobile-nav-title">{{ with .Site.Params.main.name }}{{.}}{{ end }}</h3>


### PR DESCRIPTION
- Restaura script do AdSense (ca-pub-1641452063803045) no head.html
- Remove bloco de destaque do curso da sidebar (sidenavigation.html)
- Remove link do curso do menu mobile (topnavigation.html)
- Remove script de rastreamento de checkout do curso do head.html

https://claude.ai/code/session_01WnUybWKiLZhi4QM7nqA8kL