### PR TITLE
Remove cards do curso da página inicial

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -7,16 +7,6 @@ menu: "main"
 weight: 1
 ---
 
-<div class="course-top-card">
-  <div class="course-top-card-inner">
-    <span class="course-top-card-badge">📣 Curso</span>
-    <h3 class="course-top-card-title">Curso Intensivo de Go para Iniciantes</h3>
-    <p class="course-top-card-desc">Aulas diárias por WhatsApp + PDF (10 Erros Fatais de quem começa no Go) + análise de partidas + videochamada. De iniciante a 20 kyu.</p>
-    <p class="course-top-card-note">Aulas individuais (1:1) · 30 dias · R$ 97</p>
-    <a href="/curso-go-iniciantes" class="course-top-card-btn">Ver curso e inscrever-se</a>
-  </div>
-</div>
-
 <div class="page-hero">
   <div class="hero-content">
     <h1 class="hero-title">🎯 Bem-vindo ao Baduk!</h1>
@@ -80,15 +70,6 @@ weight: 1
 </div>
 
 <div class="support-section">
-  <div class="course-top-card support-section-course-card">
-    <div class="course-top-card-inner">
-      <span class="course-top-card-badge">📣 Curso</span>
-      <h3 class="course-top-card-title">Curso Intensivo de Go para Iniciantes</h3>
-      <p class="course-top-card-desc">Aulas diárias por WhatsApp + PDF (10 Erros Fatais de quem começa no Go) + análise de partidas + videochamada. De iniciante a 20 kyu.</p>
-      <p class="course-top-card-note">Aulas individuais (1:1) · 30 dias · R$ 97</p>
-      <a href="/curso-go-iniciantes" class="course-top-card-btn">Ver curso e inscrever-se</a>
-    </div>
-  </div>
   <div class="support-card">
     <h3>💝 Apoie o Projeto</h3>
     <p>Este site é mantido gratuitamente. Sua doação ajuda a remover propagandas e melhorar o conteúdo!</p>


### PR DESCRIPTION
Remove os dois cards de promoção do curso que apareciam na página inicial (`_index.md`): um no topo e outro na seção de suporte.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WnUybWKiLZhi4QM7nqA8kL)_