### PR TITLE
Remove margin-top do page-hero para eliminar buraco abaixo do título

### DIFF
--- a/static/css/wgo.css
+++ b/static/css/wgo.css
@@ -1633,7 +1633,7 @@ input[type="text"].wgo-permalink {
   border: 2px solid #6c9922;
   border-radius: 16px;
   padding: 40px;
-  margin: 20px 0 40px 0;
+  margin: 0 0 40px 0;
   text-align: center;
   position: relative;
   overflow: hidden; }


### PR DESCRIPTION
O `margin-top: 20px` do `.page-hero` somado ao `padding: 20px` da `section` criava ~40px de espaço vazio entre o título da página e o conteúdo. Antes, o card do curso (que tinha `margin-top: 0`) ocupava esse espaço. Removido o card, o gap ficou visível. O padding da section já provê o espaçamento necessário.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WnUybWKiLZhi4QM7nqA8kL)_